### PR TITLE
fix: update dependencies in manifest.json

### DIFF
--- a/BedrockBridg_Serverpack/development_behavior_packs/Bedrock-Bridge/manifest.json
+++ b/BedrockBridg_Serverpack/development_behavior_packs/Bedrock-Bridge/manifest.json
@@ -20,7 +20,7 @@
 	"dependencies": [
 		{
 			"module_name": "@minecraft/server",
-			"version": "2.3.0-beta"
+			"version": "2.4.0-beta"
 		},
 		{
 			"module_name": "@minecraft/server-ui",
@@ -40,4 +40,5 @@
         "license": "MIT",
         "url": "https://bedrockbridge.esploratori.space/"
     }
+
 }


### PR DESCRIPTION
This pull request updates the dependencies in the `manifest.json` file for the Bedrock Bridge behavior pack. The main change is updating the version of the `@minecraft/server` module to ensure compatibility with newer features and bug fixes.

Dependency updates:

* Updated the `@minecraft/server` module version from `2.3.0-beta` to `2.4.0-beta` in `manifest.json` to support the latest API changes.

General maintenance:

* Added a newline at the end of `manifest.json` for improved formatting and convention compliance.Updated the version of the @minecraft/server dependency from 2.3.0-beta to 2.4.0-beta.