### PR TITLE
Update dependency version in manifest.json (makes it work on bedrock servers)

### DIFF
--- a/BedrockBridg_Serverpack/development_behavior_packs/Bedrock-Bridge/manifest.json
+++ b/BedrockBridg_Serverpack/development_behavior_packs/Bedrock-Bridge/manifest.json
@@ -20,7 +20,7 @@
 	"dependencies": [
 		{
 			"module_name": "@minecraft/server",
-			"version": "2.4.0-beta"
+			"version": "2.5.0-beta"
 		},
 		{
 			"module_name": "@minecraft/server-ui",
@@ -42,3 +42,4 @@
     }
 
 }
+


### PR DESCRIPTION
Updated the version of the @minecraft/server dependency from 2.4.0-beta to 2.5.0-beta.